### PR TITLE
Adds foodcritic plugin

### DIFF
--- a/plugins.yml
+++ b/plugins.yml
@@ -159,3 +159,10 @@ artifact-repository:
   repo: https://github.com/tbouron/strider-artifact-repository
   module_name: strider-artifact-repository
   type: job
+
+foodcritic:
+  description: Check your Chef cookbooks for common problems
+  tag: 1.0.1
+  repo: https://github.com/logankoester/strider-foodcritic
+  module_name: strider-foodcritic
+  type: job


### PR DESCRIPTION
Foodcritic is a helpful lint tool you can use to check your Chef cookbooks for common problems. I have written a Strider plugin for it, which you can read more about at https://github.com/logankoester/strider-foodcritic.

If this is not the correct way to submit a plugin to the ecosystem, please point me in the right direction :-)