### PR TITLE
aws-codedeploy 0.1.3

### DIFF
--- a/plugins.yml
+++ b/plugins.yml
@@ -1,7 +1,7 @@
 ---
 aws_codedeploy:
   description: integrate AWS CodeDeploy
-  tag: 0.1.2
+  tag: 0.1.3
   repo: https://github.com/flxbe/strider-aws-codedeploy.git
   module_name: strider-aws-codedeploy
   name: AWS CodeDeploy


### PR DESCRIPTION
The package.json version of the former release did not match the tag '0.1.2', so I fixed it with a new version. It should work now properly.

Sorry for that, it is my first GitHub + npm-publish.