### PR TITLE
fix(repo): remove non existing plugin (strider-hg)

### DIFF
--- a/plugins.yml
+++ b/plugins.yml
@@ -111,14 +111,6 @@ heroku:
   name: Heroku
   type: job
 
-hg:
-  description: basic mercurial provider
-  tag: 0.2.3
-  repo: https://github.com/Mixaill/strider-hg
-  module_name: strider-hg
-  name: Mercurial
-  type: provider
-
 metadata:
   description: expose job metadata as environment variables
   tag: 0.0.3


### PR DESCRIPTION
hey there,

thanks for the [tip](https://github.com/Strider-CD/strider-github/issues/25#issuecomment-264650297) to find the missing plugin in the lib/routes folder :)

![](http://i.giphy.com/XXvnnrJJnOVl6.gif)